### PR TITLE
Add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    insecure-external-code: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,10 @@
 - Abhängigkeiten aktualisiert: ``discord.py`` 2.5.2, ``Unidecode`` 1.4.0,
   ``aiosqlite`` 0.21.0, ``python-dotenv`` 1.1.1, ``pytest-asyncio`` 1.0.0 und
   ``aiohttp`` 3.12.13.
- - ChampionCog besitzt nun eine begrenzte Update-Warteschlange (1000 Einträge);
-    beim Füllen wird nun ein ``RuntimeError`` ausgelöst.
+- ChampionCog besitzt nun eine begrenzte Update-Warteschlange (1000 Einträge);
+   beim Füllen wird nun ein ``RuntimeError`` ausgelöst.
+- Neue Datei ``.github/dependabot.yml`` automatisiert Updates der
+  Python-Abhängigkeiten und GitHub-Actions.
 
 - Bereinigt: `cogs/champion/__init__.py` verwendet nun `commands.Bot` und entfernt den Import von `discord`.
 - Dokumentation erweitert: Beispiele für `/wcr`-Befehle und Hinweise zum neuen WCR-Cache.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ The project uses `pre-commit` to enforce formatting and linting
 (Black, Flake8, Ruff and pip-audit).  Security scans run automatically in
 CI using Snyk if the `SNYK_TOKEN` secret is configured.
 
+## Dependency management
+
+Dependabot checks the `requirements*.txt` files and GitHub Actions
+workflows weekly. It opens pull requests which trigger the full CI
+pipeline, ensuring updates are tested before merge.
+
 ```bash
 pre-commit run --all-files
 pytest -q

--- a/tests/general/test_dependabot.py
+++ b/tests/general/test_dependabot.py
@@ -1,0 +1,15 @@
+import yaml
+from pathlib import Path
+
+
+def test_dependabot_config_exists():
+    path = Path(".github/dependabot.yml")
+    assert path.is_file(), "dependabot.yml not found"
+
+    with open(path, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+
+    assert data.get("version") == 2
+    updates = data.get("updates", [])
+    assert any(u.get("package-ecosystem") == "github-actions" for u in updates)
+    assert any(u.get("package-ecosystem") == "pip" for u in updates)


### PR DESCRIPTION
## Summary
- automate dependency updates via Dependabot
- document Dependabot behaviour
- test for presence of the config

## Testing
- `pre-commit run --files README.md CHANGELOG.md .github/dependabot.yml tests/general/test_dependabot.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685becc6989c832f9297c421b8cafcde