### PR TITLE
Update dependabot schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,9 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     insecure-external-code: false

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,3 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    insecure-external-code: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 - Verbessertes Shutdown-Verhalten: ChampionCog schließt die Datenbank, stoppt alle Tasks und wartet auf deren Abschluss.
+- Dependabot führt Updates jetzt täglich aus.
 - Champion-Mod-Befehle verlangen nun positive Punktwerte.
 - Security-Workflow nutzt jetzt `snyk/actions/python@0.4.0` und prüft, ob `SNYK_TOKEN` gesetzt ist.
 - README beschreibt jetzt die Installation von Dev-Abhängigkeiten und das Starten des Bots per `python -m lotus_bot`.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ CI using Snyk if the `SNYK_TOKEN` secret is configured.
 ## Dependency management
 
 Dependabot checks the `requirements*.txt` files and GitHub Actions
-workflows weekly. It opens pull requests which trigger the full CI
+workflows daily. It opens pull requests which trigger the full CI
 pipeline, ensuring updates are tested before merge.
 
 ```bash


### PR DESCRIPTION
## Summary
- update dependabot schedule to run daily

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_685c1c7d2ddc832f8b1327e6aae68534