### PR TITLE
Apply lint config and translate logs

### DIFF
--- a/src/lotus_bot/cogs/ptcgp/api.py
+++ b/src/lotus_bot/cogs/ptcgp/api.py
@@ -16,7 +16,7 @@ async def fetch_all_cards(language: str) -> list[dict]:
             url = f"https://api.tcgdex.dev/v2/tcg-pocket/{language}/cards?page={page}"
             async with session.get(url, ssl=False if ssl_disabled else None) as resp:
                 if resp.status != 200:
-                    raise RuntimeError(f"HTTP {resp.status} beim Laden von {url}")
+                    raise RuntimeError(f"HTTP {resp.status} while loading {url}")
                 data = await resp.json()
                 if isinstance(data, dict) and "data" in data:
                     items = data.get("data")
@@ -26,5 +26,5 @@ async def fetch_all_cards(language: str) -> list[dict]:
                     break
                 cards.extend(items)
                 page += 1
-    logger.info(f"[PTCGP API] Geladene Karten {language}: {len(cards)}")
+    logger.info(f"[PTCGP API] Loaded {len(cards)} cards for {language}")
     return cards

--- a/src/lotus_bot/cogs/ptcgp/data.py
+++ b/src/lotus_bot/cogs/ptcgp/data.py
@@ -44,7 +44,7 @@ class PTCGPData:
         )
         await db.commit()
         self._init_done = True
-        logger.info("[PTCGPData] SQLite-Datenbank initialisiert.")
+        logger.info("[PTCGPData] SQLite database initialized.")
 
     async def close(self) -> None:
         if self.db is not None:


### PR DESCRIPTION
## Summary
- translate German log messages to English
- verify linting configuration with black, flake8, ruff and pip-audit hooks

## Testing
- `pre-commit run --files src/lotus_bot/cogs/ptcgp/api.py src/lotus_bot/cogs/ptcgp/data.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c1b50de38832fbd8fc54b16b46e89