### PR TITLE
Configure Dependabot and CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,12 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - "dependencies"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 5

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,7 +3,8 @@ name: Security Audit
 on:
   pull_request:
     paths:
-      - requirements.txt
+      - 'requirements*.txt'
+      - '.github/workflows/**'
   workflow_dispatch:
 
 jobs:
@@ -15,6 +16,16 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+      - name: Cache pre-commit
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Install pip-audit
         run: pip install pip-audit
       - name: Run pip-audit
@@ -24,6 +35,16 @@ jobs:
     needs: pip-audit
     steps:
       - uses: actions/checkout@v4
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+      - name: Cache pre-commit
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Install dependencies
         run: pip install -r requirements.txt
       - name: Generate SBOM
@@ -42,3 +63,15 @@ jobs:
         with:
           name: sbom
           path: sbom.xml
+      - name: Collect Railway logs
+        if: success()
+        run: |
+          railway logs --follow > logs/latest_railway.log &
+          sleep 30
+          pkill -f "railway logs" || true
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs
+          path: logs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 - Verbessertes Shutdown-Verhalten: ChampionCog schließt die Datenbank, stoppt alle Tasks und wartet auf deren Abschluss.
 - Dependabot führt Updates jetzt täglich aus.
+- Dependabot-Pull-Requests lösen den vollständigen CI-Workflow mit Linting,
+  Tests und Sicherheitsprüfung aus.
 - Champion-Mod-Befehle verlangen nun positive Punktwerte.
 - Security-Workflow nutzt jetzt `snyk/actions/python@0.4.0` und prüft, ob `SNYK_TOKEN` gesetzt ist.
 - README beschreibt jetzt die Installation von Dev-Abhängigkeiten und das Starten des Bots per `python -m lotus_bot`.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ CI using Snyk if the `SNYK_TOKEN` secret is configured.
 
 Dependabot checks the `requirements*.txt` files and GitHub Actions
 workflows daily. It opens pull requests which trigger the full CI
-pipeline, ensuring updates are tested before merge.
+pipeline—linting, tests and a security audit—ensuring updates are
+verified before merge.
 
 ```bash
 pre-commit run --all-files


### PR DESCRIPTION
## Summary
- ensure Dependabot daily updates with labels
- cache pip and pre-commit in security workflow and upload logs
- clarify Dependabot behaviour in README
- note CI behaviour in CHANGELOG

## Testing
- `pre-commit run --all-files --show-diff-on-failure`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c77b82cec832fb424294b10ea184e