### PR TITLE
Improve docs and inline comments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@
 
 bot_key=DEIN_DISCORD_TOKEN
 server_id=DEINE_SERVER_ID
+# Log-Level für structlog (z.B. INFO oder DEBUG)
 LOG_LEVEL=INFO
 # Basis-URL der WCR-API
 WCR_API_URL=https://wcr-api.up.railway.app

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,4 +44,6 @@
 - Behoben: Manuelle Snyk-Authentifizierung entfernt, Token wird über die Setup-Action gesetzt.
 - Behoben: Snyk-Workflow ruft ``snyk auth`` mit dem Token auf.
 - Behoben: Entfernt erneut den ``snyk auth``-Schritt, da die Setup-Action den
-  Token automatisch verwendet.
+    Token automatisch verwendet.
+- README folgt nun der globalen Struktur und `.env.example` dokumentiert alle
+  benötigten Variablen.

--- a/README.md
+++ b/README.md
@@ -1,51 +1,53 @@
 # Lotus Discord Bot
 
-This project contains the source code for Lotus Gaming's community bot.
-It is developed using the [discord.py](https://discordpy.readthedocs.io/) library.
+Lotus Gaming's community bot built with
+[discord.py](https://discordpy.readthedocs.io/).
 
-## Quick start
+## Setup
 
-1. Install Python 3.11.
+1. Install Python **3.11**.
 2. Install the runtime dependencies:
    ```bash
    pip install -r requirements.txt
    ```
-3. Install development tools:
+3. Install development tools and pre-commit hooks:
    ```bash
    pip install -r requirements-dev.txt
    pre-commit install
    ```
 4. Copy `.env.example` to `.env` and adjust the values.
-5. Run the bot:
-   ```bash
-   python -m lotus_bot
-   ```
+
+## Usage
+
+Run the bot locally:
+
+```bash
+python -m lotus_bot
+```
 
 ## Development
 
-All source code lives under `src/lotus_bot/` using the src layout.  Tests
-reside in the `tests/` directory and are executed with `pytest`.
-
-The project uses `pre-commit` to enforce formatting and linting
-(Black, Flake8, Ruff and pip-audit).  Security scans run automatically in
-CI using Snyk if the `SNYK_TOKEN` secret is configured.
-
-## Dependency management
-
-Dependabot checks the `requirements*.txt` files and GitHub Actions
-workflows daily. It opens pull requests which trigger the full CI
-pipeline—linting, tests and a security audit—ensuring updates are
-verified before merge.
+Source code lives under `src/lotus_bot/` while tests reside in `tests/`.
+Run the following commands before committing code:
 
 ```bash
 pre-commit run --all-files
-pytest -q
+pytest --cov=.
 ```
+
+`pre-commit` enforces formatting and linting (Black, Flake8, Ruff) and
+executes `pip-audit`. Security scans also run in CI via Snyk when
+`SNYK_TOKEN` is configured.
+
+Dependabot checks dependencies daily and opens pull requests that run the
+full CI pipeline.
 
 ## Deployment
 
-The bot runs on Railway. Logs are written to `logs/bot.json` in JSON
-format using structlog. Internal log messages are in English while all
-user-facing messages remain German. CI uploads the latest Railway logs
-as build artifacts.
-Secrets like `bot_key` and `server_id` are provided as Railway environment variables. The `.env.example` file lists all required values, which Railway injects into the runtime container.
+The bot is deployed on Railway. Logs are written to `logs/bot.json` in
+JSON format using structlog. Internal log messages are in English while
+user-facing messages are German. CI uploads the latest Railway logs as
+build artifacts.
+
+Environment variables such as `bot_key` and `server_id` are provided via
+Railway. The `.env.example` file lists all required values.

--- a/src/lotus_bot/__main__.py
+++ b/src/lotus_bot/__main__.py
@@ -2,10 +2,13 @@ from .bot import MyBot
 import os
 
 
-def main():
+def main() -> None:
+    """Entry point used by ``python -m lotus_bot``."""
+
     token = os.getenv("bot_key")
     if not token:
         raise SystemExit("Environment variable 'bot_key' is not set.")
+
     bot = MyBot()
     bot.run(token)
 

--- a/src/lotus_bot/bot.py
+++ b/src/lotus_bot/bot.py
@@ -65,6 +65,8 @@ def load_quiz_config(bot: commands.Bot):
         language = cfg.get("language", "de")
 
         dynamic_providers = {}
+        # Each area may define a ``get_provider`` function to generate
+        # additional questions at runtime. Import it dynamically if present.
         try:
             module = __import__(
                 f"cogs.quiz.area_providers.{area}", fromlist=["get_provider"]

--- a/src/lotus_bot/cogs/champion/cog.py
+++ b/src/lotus_bot/cogs/champion/cog.py
@@ -100,7 +100,11 @@ class ChampionCog(ManagedTaskCog):
             await self._apply_champion_role(user_id_str, total)
 
     async def _worker(self) -> None:
-        """Verarbeitet Punktänderungen aus der Warteschlange nacheinander."""
+        """Apply queued score updates sequentially in the background."""
+
+        # This long running task processes the ``update_queue`` until the cog is
+        # unloaded. It ensures that role updates happen in order and catches
+        # ``CancelledError`` when the bot shuts down.
         try:
             while True:
                 user_id_str, total = await self.update_queue.get()

--- a/src/lotus_bot/cogs/wcr/cog.py
+++ b/src/lotus_bot/cogs/wcr/cog.py
@@ -459,7 +459,13 @@ class WCRCog(commands.Cog):
         level_b: int = 1,
         lang: str = "de",
     ) -> DuelOutcome:
-        """Berechne den Ergebnistext für ``/wcr duell``."""
+        """Berechne den Ergebnistext für ``/wcr duell``.
+
+        Dabei werden die beiden Minis auf die gewählten Level skaliert und ihre
+        Schadenswerte gegeneinander verglichen. Das Ergebnis enthält einen
+        deutschsprachigen Hinweis, welches Mini gewinnt oder ob kein Treffer
+        möglich ist.
+        """
 
         res_a = self.resolve_unit(mini_a, lang)
         res_b = self.resolve_unit(mini_b, lang)
@@ -483,10 +489,14 @@ class WCRCog(commands.Cog):
         dps_b, notes_b = calculator.compute_dps_details(data_b, stats_b, data_a)
 
         def _flight_issue(att: dict, def_: dict) -> bool:
+            """Return True if ``att`` cannot hit ``def_`` due to flying."""
+
             ta = [str(t) for t in att.get("trait_ids", [])]
             td = [str(t) for t in def_.get("trait_ids", [])]
             if att.get("type_id") == "2":
+                # Spells always hit flying targets
                 return False
+            # Trait 15 = Flying. Trait 11/15 allow hitting flying units
             return "15" in td and "11" not in ta and "15" not in ta
 
         issue_a = _flight_issue(data_a, data_b)


### PR DESCRIPTION
## Summary
- align README structure with global docs
- mention docs update in CHANGELOG
- clarify env var description in `.env.example`
- add docstring for module entry point
- explain dynamic quiz providers in `bot.py`
- document champion worker loop
- detail duel outcome computation

## Testing
- `pre-commit run --files README.md CHANGELOG.md .env.example src/lotus_bot/__main__.py src/lotus_bot/bot.py src/lotus_bot/cogs/champion/cog.py src/lotus_bot/cogs/wcr/cog.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c84c84c3c832f931d425582590079