### PR TITLE
Fix Snyk scanning in CI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,5 @@ WCR_CACHE_TTL=86400
 PTCGP_SKIP_SSL_VERIFY=0
 # Optional: Pfad zur Champion-Datenbank
 CHAMPION_DB_PATH=data/pers/champion/points.db
+# Optional: Token für Snyk-Scans
+SNYK_TOKEN=

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -49,11 +49,13 @@ jobs:
         run: pip install -r requirements.txt
       - name: Generate SBOM
         run: cyclonedx-bom -o sbom.xml
+      - name: Install Snyk CLI
+        run: npm install -g snyk
       - name: Snyk Test
-        if: ${{ secrets.SNYK_TOKEN != '' && github.event.pull_request.head.repo.full_name == github.repository }}
         run: snyk test
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        if: ${{ env.SNYK_TOKEN != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
       - name: Upload SBOM
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- install Snyk CLI before running security scan
- guard Snyk step against missing token and forked PRs
- document `SNYK_TOKEN` in `.env.example`

## Testing
- `pre-commit run --files .github/workflows/security.yml .env.example`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d2e866920832fad927435ee7c0463