### PR TITLE
Update logging and workflows

### DIFF
--- a/.github/workflows/railway_logs.yml
+++ b/.github/workflows/railway_logs.yml
@@ -9,15 +9,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Railway CLI
-        run: npm install -g railway
-      - name: Login to Railway
+        run: npx @railway/cli --version
+      - name: Stream logs
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
-        run: railway login --token $RAILWAY_TOKEN
-      - name: Stream logs
+          RAILWAY_SERVICE: ${{ secrets.RAILWAY_SERVICE }}
+          RAILWAY_PROJECT: ${{ secrets.RAILWAY_PROJECT }}
         run: |
           mkdir -p logs
-          railway logs --follow > logs/latest_railway.log
+          npx railway logs --service "$RAILWAY_SERVICE" --project "$RAILWAY_PROJECT" --env production --json > logs/latest_railway.log
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -68,8 +68,12 @@ jobs:
           path: sbom.xml
       - name: Collect Railway logs
         if: success()
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_SERVICE: ${{ secrets.RAILWAY_SERVICE }}
+          RAILWAY_PROJECT: ${{ secrets.RAILWAY_PROJECT }}
         run: |
-          railway logs --follow > logs/latest_railway.log &
+          npx railway logs --service "$RAILWAY_SERVICE" --project "$RAILWAY_PROJECT" --env production --json > logs/latest_railway.log &
           sleep 30
           pkill -f "railway logs" || true
       - name: Upload logs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,8 +50,12 @@ jobs:
           pytest --cov=. --cov-fail-under=90
       - name: Collect Railway logs
         if: success()
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_SERVICE: ${{ secrets.RAILWAY_SERVICE }}
+          RAILWAY_PROJECT: ${{ secrets.RAILWAY_PROJECT }}
         run: |
-          railway logs --follow > logs/latest_railway.log &
+          npx railway logs --service "$RAILWAY_SERVICE" --project "$RAILWAY_PROJECT" --env production --json > logs/latest_railway.log &
           sleep 30
           pkill -f "railway logs" || true
       - name: Upload logs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 - Verbessertes Shutdown-Verhalten: ChampionCog schließt die Datenbank, stoppt alle Tasks und wartet auf deren Abschluss.
 - Guidelines-Dokument und CLI-Skript `fetch_wcr.py` hinzugefügt; Coverage-Konfiguration über `.coveragerc`.
+- Logging rotiert stündlich und schreibt nach `logs/runtime-<YYYY-MM-DD-HH>.json`.
 - Abhängigkeit `idna>=3.7` hinzugefügt, um Snyk-Warnung zu beheben.
 - Dependabot führt Updates jetzt täglich aus.
 - Dependabot-Pull-Requests lösen den vollständigen CI-Workflow mit Linting,

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ CI pipeline.
 
 ## Deployment
 
-The bot is deployed on Railway. Logs are stored in `logs/bot.json` and CI uploads
+The bot is deployed on Railway. Logs are written to files named
+`logs/runtime-<YYYY-MM-DD-HH>.json` and CI uploads
 `logs/latest_railway.log` as an artifact. Internal log messages are in English
 while user-facing messages are in German.
 

--- a/tests/general/test_log_setup.py
+++ b/tests/general/test_log_setup.py
@@ -15,8 +15,7 @@ def test_setup_logging_writes_json(tmp_path):
     finally:
         os.chdir(old_cwd)
 
-    log_file = tmp_path / "logs" / "bot.json"
-    assert log_file.exists()
+    log_file = next((tmp_path / "logs").glob("runtime-*.json"))
     data = json.loads(log_file.read_text().splitlines()[-1])
     assert data["event"] == "hello"
     assert data["value"] == 1


### PR DESCRIPTION
## Summary
- rotate bot logs hourly with new `HourlyFileHandler`
- collect Railway logs using `npx railway` in workflows
- store runtime logs under `logs/runtime-<YYYY-MM-DD-HH>.json`
- adjust tests for new log path
- document log path in README

## Testing
- `pre-commit run --all-files`
- `pytest --cov=. --cov-fail-under=90`

------
https://chatgpt.com/codex/tasks/task_e_685e7563d09c832f8cbb99f1f1b24744