### PR TITLE
Use variables for Railway service and project

### DIFF
--- a/.github/workflows/railway_logs.yml
+++ b/.github/workflows/railway_logs.yml
@@ -13,8 +13,8 @@ jobs:
       - name: Stream logs
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
-          RAILWAY_SERVICE: ${{ secrets.RAILWAY_SERVICE }}
-          RAILWAY_PROJECT: ${{ secrets.RAILWAY_PROJECT }}
+          RAILWAY_SERVICE: ${{ vars.RAILWAY_SERVICE }}
+          RAILWAY_PROJECT: ${{ vars.RAILWAY_PROJECT }}
         run: |
           mkdir -p logs
           npx railway logs --service "$RAILWAY_SERVICE" --project "$RAILWAY_PROJECT" --env production --json > logs/latest_railway.log

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -70,8 +70,8 @@ jobs:
         if: success()
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
-          RAILWAY_SERVICE: ${{ secrets.RAILWAY_SERVICE }}
-          RAILWAY_PROJECT: ${{ secrets.RAILWAY_PROJECT }}
+          RAILWAY_SERVICE: ${{ vars.RAILWAY_SERVICE }}
+          RAILWAY_PROJECT: ${{ vars.RAILWAY_PROJECT }}
         run: |
           npx railway logs --service "$RAILWAY_SERVICE" --project "$RAILWAY_PROJECT" --env production --json > logs/latest_railway.log &
           sleep 30

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,8 +52,8 @@ jobs:
         if: success()
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
-          RAILWAY_SERVICE: ${{ secrets.RAILWAY_SERVICE }}
-          RAILWAY_PROJECT: ${{ secrets.RAILWAY_PROJECT }}
+          RAILWAY_SERVICE: ${{ vars.RAILWAY_SERVICE }}
+          RAILWAY_PROJECT: ${{ vars.RAILWAY_PROJECT }}
         run: |
           npx railway logs --service "$RAILWAY_SERVICE" --project "$RAILWAY_PROJECT" --env production --json > logs/latest_railway.log &
           sleep 30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   Tests und Sicherheitsprüfung aus.
 - Champion-Mod-Befehle verlangen nun positive Punktwerte.
 - Security-Workflow nutzt jetzt `snyk/actions/python@0.4.0` und prüft, ob `SNYK_TOKEN` gesetzt ist.
+- GitHub-Workflows beziehen `RAILWAY_PROJECT` und `RAILWAY_SERVICE` nun über
+  Repository-Variablen statt Secrets.
 - README beschreibt jetzt die Installation von Dev-Abhängigkeiten und das Starten des Bots per `python -m lotus_bot`.
 - WCR-Cog aufgeteilt: Namensauflösung und Embed-Aufbau sind nun in eigenen Modulen. Fehlerbehandlung und Tests wurden erweitert.
 - ChampionCog.update_user_score loggt jetzt Datenbankfehler und wirft einen

--- a/README.md
+++ b/README.md
@@ -57,3 +57,7 @@ while user-facing messages are in German.
 
 All environment variables are documented in `.env.example` and supplied via
 Railway.
+
+CI jobs access Railway via the CLI. They expect `RAILWAY_TOKEN` to be defined as
+ a secret and the variables `RAILWAY_PROJECT` and `RAILWAY_SERVICE` to be
+ available at the repository or organisation level.


### PR DESCRIPTION
## Summary
- source Railway service and project from repo variables instead of secrets
- document new setup in README
- note change in changelog

## Testing
- `pre-commit run --all-files --show-diff-on-failure`
- `pytest --cov=. --cov-fail-under=90`


------
https://chatgpt.com/codex/tasks/task_e_6860876fa6b8832f9f0a5067618d9041